### PR TITLE
Fix IBD block sync: properly handle fork detection when tip is common…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,7 @@ set(MIQ_CORE_SOURCES_NO_NAT
     src/wallet_store.h src/wallet_store.cpp
     src/reindex_utxo.h
     src/reindex_utxo.cpp
+    src/ensure_utxo_reindex.cpp
     src/constants.h
     src/config.h src/config.cpp
     src/log.h src/log.cpp

--- a/src/cli/miqminer_rpc.cpp
+++ b/src/cli/miqminer_rpc.cpp
@@ -1539,11 +1539,14 @@ static void pin_thread_to_cpu(unsigned tid){
 #if defined(_WIN32)
     DWORD_PTR mask = (DWORD_PTR)1 << (tid % (8*sizeof(DWORD_PTR)));
     SetThreadAffinityMask(GetCurrentThread(), mask);
-#else
+#elif defined(__linux__)
     cpu_set_t set;
     CPU_ZERO(&set);
     CPU_SET(tid % CPU_SETSIZE, &set);
     sched_setaffinity(0, sizeof(set), &set);
+#else
+    // macOS and other platforms don't have sched_setaffinity
+    (void)tid;  // suppress unused warning
 #endif
 }
 

--- a/src/ensure_utxo_reindex.cpp
+++ b/src/ensure_utxo_reindex.cpp
@@ -1,0 +1,41 @@
+#include "chain.h"
+#include "utxo_kv.h"
+#include "reindex_utxo.h"
+#include "log.h"
+#include <string>
+
+namespace miq {
+
+// This function is declared as weak in main.cpp and linked only if this file is compiled.
+// It wraps the ReindexUTXO function to provide UTXO reindexing capability.
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(_WIN32)
+__attribute__((weak))
+#endif
+bool ensure_utxo_fully_indexed(Chain& chain, const std::string& datadir, bool force_reindex) {
+    if (!force_reindex) {
+        // If not forcing reindex, just return success (UTXO will be built incrementally)
+        return true;
+    }
+
+    log_info("Starting UTXO reindex...");
+
+    // Open the UTXO key-value store
+    UTXOKV kv;
+    std::string err;
+    if (!kv.open(datadir, &err)) {
+        log_error("Failed to open UTXO database: " + err);
+        return false;
+    }
+
+    // Perform the full reindex
+    if (!ReindexUTXO(chain, kv, true, err)) {
+        log_error("UTXO reindex failed: " + err);
+        return false;
+    }
+
+    log_info("UTXO reindex completed successfully");
+    return true;
+}
+
+}  // namespace miq
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,9 @@
 #  include "reindex_utxo.h"
 #endif
 #if (defined(__GNUC__) || defined(__clang__)) && !defined(_WIN32)
-extern bool ensure_utxo_fully_indexed(miq::Chain&, const std::string&, bool) __attribute__((weak));
+namespace miq {
+extern bool ensure_utxo_fully_indexed(Chain&, const std::string&, bool) __attribute__((weak));
+}
 #  define MIQ_CAN_PROBE_UTXO_REINDEX 1
 #else
 #  define MIQ_CAN_PROBE_UTXO_REINDEX 0


### PR DESCRIPTION
… ancestor

The issue was in find_header_fork() and next_block_fetch_targets():
- When walking up from best_header, if parent is not in header_index but is the tip, we should recognize the tip as the common ancestor
- In next_block_fetch_targets(), we need to use the 'up' path (blocks from best_header to common ancestor) in reverse order to get the blocks to download
- This fixes the case where headers are accepted but blocks are not being requested