### PR TITLE
Fix Windows MSVC compilation errors

### DIFF
--- a/src/log.h
+++ b/src/log.h
@@ -12,12 +12,13 @@
 namespace miq {
 
 // Log levels (production-grade)
+// Note: Using ERR instead of ERROR to avoid conflict with Windows ERROR macro
 enum class LogLevel : int {
     TRACE = 0,    // Extremely verbose
     DEBUG = 1,    // Debug information
     INFO = 2,     // General information
     WARN = 3,     // Warnings
-    ERROR = 4,    // Errors
+    ERR = 4,      // Errors (named ERR to avoid Windows macro conflict)
     FATAL = 5,    // Fatal errors
     NONE = 6      // Disable all logging
 };
@@ -91,7 +92,7 @@ void log_fatal(LogCategory cat, const std::string& s);
 } while(0)
 
 #define MIQ_LOG_ERROR(cat, msg) do { \
-    if (miq::log_get_level() <= miq::LogLevel::ERROR && \
+    if (miq::log_get_level() <= miq::LogLevel::ERR && \
         (miq::log_get_categories() & static_cast<uint32_t>(cat))) { \
         miq::log_error(cat, msg); \
     } \

--- a/src/mempool.h
+++ b/src/mempool.h
@@ -88,7 +88,8 @@ struct MempoolEntry {
     // Mining score (higher = more likely to be mined)
     double mining_score() const {
         // CPFP-aware: use the better of individual or package rate
-        return std::max(fee_rate, modified_fee_rate);
+        // Note: Using (std::max) with parentheses to avoid Windows max macro conflict
+        return (std::max)(fee_rate, modified_fee_rate);
     }
 };
 


### PR DESCRIPTION
- Rename LogLevel::ERROR to LogLevel::ERR to avoid conflict with Windows ERROR macro (defined as 0 in Windows headers)
- Wrap std::max() call in parentheses in mempool.h to prevent Windows max macro expansion

These macro conflicts were causing cascading syntax errors when compiling on Windows with MSVC, particularly affecting log.h, mempool.h, and any files that included them (chain.h, p2p.cpp, ibd_monitor.cpp, miner.cpp).