### PR TITLE
Fix miner RPC connection and wallet balance visibility

### DIFF
--- a/src/cli/miqminer_rpc.cpp
+++ b/src/cli/miqminer_rpc.cpp
@@ -2331,9 +2331,12 @@ int main(int argc, char** argv){
         while (ui.running.load()) {
             MinerTemplate tpl;
             if (!rpc_getminertemplate(rpc_host, rpc_port, token, tpl)) {
-                std::ostringstream m; m << C("31;1") << "template error — check RPC token or node" << R();
+                std::ostringstream m;
+                m << C("31;1") << "CANNOT MINE: Node not responding at " << rpc_host << ":" << rpc_port << R() << "\n";
+                m << C("33") << "  Ensure miqrochain node is running with RPC enabled\n";
+                m << "  Check: 1) Node running  2) RPC port " << rpc_port << "  3) Token/cookie" << R();
                 { std::lock_guard<std::mutex> lk(ui.mtx); ui.last_submit_msg = m.str(); ui.last_submit_when = std::chrono::steady_clock::now(); }
-                log_line("template error (getminertemplate failed)");
+                log_line("template error: node not responding at " + rpc_host + ":" + std::to_string(rpc_port));
                 for(int i=0;i<20 && ui.running.load(); ++i) miq_sleep_ms(100);
                 continue;
             }

--- a/src/wallet/spv_simple.cpp
+++ b/src/wallet/spv_simple.cpp
@@ -613,12 +613,14 @@ bool spv_collect_utxos(const std::string& p2p_host, const std::string& p2p_port,
     save_state(opt.cache_dir, newst);
     save_utxo_cache(opt.cache_dir, view);
 
-    // 9) post-filter: require ≥1 conf for all; coinbases need full maturity
+    // 9) post-filter: require ≥1 conf for all outputs
+    // NOTE: We return immature coinbase so wallet can display them as "Immature" balance
+    // The wallet will filter them from spendable but show them in the UI
     std::vector<UtxoLite> finalv; finalv.reserve(view.size());
     for(const auto& u : view){
         uint32_t conf = (u.height <= tip_height) ? (tip_height - u.height + 1) : 0;
         if(conf < 1) continue;
-        if(u.coinbase && conf < COINBASE_MATURITY) continue;
+        // Don't filter immature coinbase - let wallet display them as immature balance
         finalv.push_back(u);
     }
 


### PR DESCRIPTION
Critical fixes for local mining and wallet balance display:

1. Wallet localhost priority: Move localhost (127.0.0.1) to top of seed list so wallet connects to local node first. This ensures miners see their locally mined blocks instead of connecting to remote seeds.

2. SPV coinbase filtering: Remove premature filtering of immature coinbase outputs. Previously, SPV would filter out coinbase with < 100 confs, causing wallet to never display "Immature" balance. Now wallet can properly show immature coinbase in the UI.

3. Improved error diagnostics: Better error messages when miner cannot connect to RPC (explains need for running node) and when wallet SPV sync fails (troubleshooting steps for local miners).

These fixes address the issue where miners see UNREACHABLE status and wallet shows 0 balance despite having mined thousands of blocks locally.