### PR TITLE
Fix wallet to show only loaded wallet's balance and miner RPC status

### DIFF
--- a/src/cli/miqminer_rpc.cpp
+++ b/src/cli/miqminer_rpc.cpp
@@ -2495,6 +2495,7 @@ int main(int argc, char** argv){
         while (ui.running.load()) {
             MinerTemplate tpl;
             if (!rpc_getminertemplate(rpc_host, rpc_port, token, tpl)) {
+                ui.node_reachable.store(false);
                 std::ostringstream m;
                 m << C("31;1") << "CANNOT MINE: Node not responding at " << rpc_host << ":" << rpc_port << R() << "\n";
                 m << C("33") << "  Ensure miqrochain node is running with RPC enabled\n";
@@ -2504,6 +2505,9 @@ int main(int argc, char** argv){
                 for(int i=0;i<20 && ui.running.load(); ++i) miq_sleep_ms(100);
                 continue;
             }
+
+            // Successfully got template - node is reachable
+            ui.node_reachable.store(true);
 
             if (tpl.prev_hash.size() != 32) {
                 log_line("template rejected: prev_hash size invalid");


### PR DESCRIPTION
Wallet: Fixed SPV to filter UTXOs by wallet's PKHs (public key hashes)
- Added PKH filtering in final output to only return UTXOs belonging to wallet
- Added re-filtering of cached UTXOs when loading to prevent showing other wallets' balances
- Wallet now correctly displays balance for the seed it was loaded from, not entire blockchain

Miner: Fixed RPC reachable status display
- Mining thread now updates ui.node_reachable when template fetch succeeds
- Sets flag to false when template fetch fails for accurate status
- Fixes false "UNREACHABLE" display while miner is actually getting jobs