### PR TITLE
Fix miner RPC connection and estimated earnings display bugs

### DIFF
--- a/src/cli/miqminer_rpc.cpp
+++ b/src/cli/miqminer_rpc.cpp
@@ -845,12 +845,13 @@ static bool rpc_getcoinbaserecipient(const std::string& host, uint16_t port, con
     HttpResp r;
     if(!http_post(host, port, "/", auth, rpc_build("getcoinbaserecipient", ps.str()), r) || r.code!=200) return false;
     if(json_has_error(r.body)) return false;
-    std::string pkh_hex, txid_hex; long long val=0;
+    std::string pkh_hex, txid_hex;
+    double val_dbl = 0.0;
     if(!json_find_string(r.body, "pkh", pkh_hex)) return false;
-    (void)json_find_number(r.body, "value", val);
+    (void)json_find_double(r.body, "value", val_dbl);
     if(json_find_string(r.body, "txid", txid_hex)) io.coinbase_txid_hex = txid_hex;
     io.coinbase_pkh = from_hex_s(pkh_hex);
-    io.reward_value = (uint64_t)((val<0)?0:val);
+    io.reward_value = (uint64_t)((val_dbl < 0.0) ? 0 : val_dbl);
     return true;
 }
 static double estimate_network_hashps(const std::string& host, uint16_t port, const std::string& auth, uint64_t tip_height, uint32_t bits){

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -563,10 +563,13 @@ std::string RpcService::handle(const std::string& body){
         }
 
         if(method=="getblockchaininfo"){
+            auto tip = chain_.tip();
             JNode n; std::map<std::string,JNode> o;
             JNode a; a.v = std::string(CHAIN_NAME);              o["chain"] = a;
-            JNode h; h.v = (double)chain_.tip().height;          o["height"] = h;
-            JNode d; d.v = (double)Chain::work_from_bits_public(chain_.tip().bits); o["difficulty"] = d;
+            JNode h; h.v = (double)tip.height;                   o["height"] = h;
+            JNode b; b.v = (double)tip.height;                   o["blocks"] = b;  // alias for height
+            JNode hh; hh.v = to_hex(tip.hash);                   o["bestblockhash"] = hh;
+            JNode d; d.v = (double)Chain::work_from_bits_public(tip.bits); o["difficulty"] = d;
             JNode r; r.v = o; return json_dump(r);
         }
 


### PR DESCRIPTION
This commit fixes two critical bugs in the miner RPC interface:

1. RPC Connection Status Always Shows "NOT CONNECTED"
   - Root cause: getblockchaininfo RPC was missing 'blocks' and 'bestblockhash' fields
   - The miner's fallback path in rpc_gettipinfo() expects these fields
   - When gettipinfo fast-path fails, the fallback calls getblockchaininfo
   - Missing fields caused the entire function to fail, marking node as unreachable
   - Fix: Added 'blocks' (alias for height) and 'bestblockhash' fields to getblockchaininfo response
   - Location: src/rpc.cpp:565-573

2. Estimated Earnings Displays Incorrect Low Values (e.g., 0.00002450 MIQ instead of 50 MIQ)
   - Root cause: json_find_number() cannot parse floating-point or scientific notation
   - The RPC returns coinbase value as double (e.g., "5e9" or "5000000000.0")
   - json_find_number() only reads digits before decimal/exponent, truncating the value
   - Example: "5000000000.0" parsed as "5000000000", but "5.0e9" parsed as only "5"
   - Fix: Changed to json_find_double() which properly handles all numeric formats
   - Location: src/cli/miqminer_rpc.cpp:841-855

These fixes ensure the miner correctly displays RPC connection status and accurately calculates estimated mining rewards.