### PR TITLE
Fix MSVC build errors and warnings in p2p.cpp and rpc.cpp

### DIFF
--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -1703,7 +1703,7 @@ std::string RpcService::handle(const std::string& body){
             std::vector<OwnedUtxo> spendables;  // filtered mature funds
 
             uint64_t total_balance = 0, spendable_balance = 0, locked_balance = 0;
-            uint64_t soonest_mature_h = std::numeric_limits<uint64_t>::max();
+            uint64_t soonest_mature_h = (std::numeric_limits<uint64_t>::max)();
 
             auto maybe_push = [&](uint32_t chain, uint32_t limit){
                 // Scan up to limit + GAP_LIMIT to find externally-used addresses
@@ -1746,7 +1746,7 @@ std::string RpcService::handle(const std::string& body){
             if (owned_all.empty()) return err("no funds");
 
             if (spendables.empty()) {
-                if (locked_balance > 0 && soonest_mature_h != std::numeric_limits<uint64_t>::max()) {
+                if (locked_balance > 0 && soonest_mature_h != (std::numeric_limits<uint64_t>::max)()) {
                     char buf[160];
                     std::snprintf(buf, sizeof(buf),
                                   "no spendable utxos: %llu locked until height %llu",


### PR DESCRIPTION
- Fix Windows max macro conflict with std::numeric_limits by using parenthesization trick: (std::numeric_limits<uint64_t>::max)()
- Silence unused variable warnings (local_port, sent, result) that are only used when P2P_TRACE is enabled
- Remove unreferenced functions: unsolicited_drop() and self_add_be()