### PR TITLE
Fix MSVC build warnings and errors

### DIFF
--- a/src/cli/miqwallet.cpp
+++ b/src/cli/miqwallet.cpp
@@ -23,6 +23,7 @@
 #include <unordered_set>
 #include <unordered_map>
 #include <set>
+#include <map>
 #include <cstdint>
 #include <atomic>
 #include <mutex>
@@ -1514,8 +1515,8 @@ static TransactionBuildResult build_transaction_smart(
     const std::set<OutpointKey>& pending_utxos,
     const std::vector<uint8_t>& seed,
     miq::HdAccountMeta& meta,
-    const std::string& wdir,
-    const std::string& pass)
+    [[maybe_unused]] const std::string& wdir,
+    [[maybe_unused]] const std::string& pass)
 {
     TransactionBuildResult result;
 
@@ -6351,9 +6352,9 @@ static bool wallet_session(const std::string& cli_host,
                           << " (" << ui::yellow() << fmt_amount(pending_value) << " MIQ held" << ui::reset() << ")\n";
             }
 
-            int queue_count = count_pending_in_queue(wdir);
-            if(queue_count > 0){
-                std::cout << "    Queued TXs:       " << ui::yellow() << queue_count << ui::reset()
+            int queued_tx_count = count_pending_in_queue(wdir);
+            if(queued_tx_count > 0){
+                std::cout << "    Queued TXs:       " << ui::yellow() << queued_tx_count << ui::reset()
                           << ui::dim() << " (awaiting broadcast)" << ui::reset() << "\n";
             }
             std::cout << "\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1084,29 +1084,15 @@ template<typename H> struct has_nBits_field<H, std::void_t<decltype(std::declval
 
 template<typename H>
 static uint64_t hdr_time(const H& h){
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4702)  // Unreachable code from if constexpr
-#endif
     if constexpr (has_time_field<H>::value) return (uint64_t)h.time;
-    if constexpr (has_timestamp_field<H>::value) return (uint64_t)h.timestamp;
-    return 0;
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+    else if constexpr (has_timestamp_field<H>::value) return (uint64_t)h.timestamp;
+    else return 0;
 }
 template<typename H>
 static uint32_t hdr_bits(const H& h){
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4702)  // Unreachable code from if constexpr
-#endif
     if constexpr (has_bits_field<H>::value) return (uint32_t)h.bits;
-    if constexpr (has_nBits_field<H>::value) return (uint32_t)h.nBits;
-    return (uint32_t)GENESIS_BITS;
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+    else if constexpr (has_nBits_field<H>::value) return (uint32_t)h.nBits;
+    else return (uint32_t)GENESIS_BITS;
 }
 
 // Difficulty helpers


### PR DESCRIPTION
- Fix unreachable code warnings (C4702) in main.cpp by using else-if constexpr chains instead of sequential if constexpr statements
- Add missing #include <map> in miqwallet.cpp to fix C2039 error
- Mark unused parameters (wdir, pass) with [[maybe_unused]] attribute
- Rename shadowed variable queue_count to queued_tx_count (C4456)