### PR TITLE
Fix daemon UTF-8 display on Windows consoles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,12 @@ if(MSVC)
   add_compile_options(/W4 /permissive- /Zc:__cplusplus)
   add_definitions(/D_CRT_SECURE_NO_WARNINGS)
   add_compile_definitions(_WIN32_WINNT=0x0600)
+  # UTF-8 source and execution character set for proper Unicode TUI display
+  add_compile_options(/utf-8)
 else()
   add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers)
+  # UTF-8 source and execution character set for GCC/Clang (proper Unicode TUI display)
+  add_compile_options(-finput-charset=UTF-8 -fexec-charset=UTF-8)
 endif()
 
 # ---------------- DB (LevelDB default) ----------------

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,20 @@
+// =============================================================================
+// UTF-8 Source/Execution Encoding - Essential for Unicode TUI characters
+// =============================================================================
+// This file MUST be saved as UTF-8 (with or without BOM) for Unicode literals
+// to work correctly. The pragmas/defines below tell the compiler to interpret
+// source as UTF-8 and produce UTF-8 string literals in the binary.
+
 #ifdef _MSC_VER
+  // MSVC: /utf-8 or this pragma ensures UTF-8 encoding
   #pragma execution_character_set("utf-8")
   #ifndef _CRT_SECURE_NO_WARNINGS
     #define _CRT_SECURE_NO_WARNINGS
   #endif
 #endif
+
+// GCC/Clang: No pragma needed if compiled with -finput-charset=UTF-8 -fexec-charset=UTF-8
+// (see CMakeLists.txt). The u8"" prefix can be used for explicit UTF-8 strings.
 
 // =============================================================================
 // Windows portability flags
@@ -760,42 +771,74 @@ static inline void enable_vt_and_probe_u8(bool& vt_ok, bool& u8_ok) {
 } // namespace term
 
 // Console writer avoids recursion with log capture - IMPROVED for PowerShell 5+
+// Uses WriteConsoleW exclusively on Windows to bypass byte-stream layer encoding issues
 class ConsoleWriter {
 public:
     ConsoleWriter(){ init(); }
     ~ConsoleWriter(){
 #ifdef _WIN32
-        if (hFile_ && hFile_ != INVALID_HANDLE_VALUE) CloseHandle(hFile_);
+        if (hConOut_ && hConOut_ != INVALID_HANDLE_VALUE) CloseHandle(hConOut_);
 #else
         if (fd_ >= 0 && fd_ != STDOUT_FILENO) ::close(fd_);
 #endif
     }
 
     // Optimized write with buffering for reduced flicker on PowerShell 5+
+    // CRITICAL: Uses WriteConsoleW to bypass the problematic byte-stream layer
     void write_raw(const std::string& s){
         if (s.empty()) return;
 #ifdef _WIN32
-        // For PowerShell 5+ compatibility: use WriteConsoleW for proper Unicode support
-        // Convert UTF-8 to wide string and use WriteConsoleW
+        // ALWAYS use WriteConsoleW for proper UTF-8 display on Windows consoles
+        // This bypasses the problematic byte-stream layer that causes mojibake
+        // even when SetConsoleOutputCP(CP_UTF8) is set.
+        //
+        // The issue: Windows console's byte-stream mode doesn't properly handle
+        // multi-byte UTF-8 sequences. By converting to UTF-16 and using
+        // WriteConsoleW, we write directly to the console buffer.
+
         int wlen = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), (int)s.size(), NULL, 0);
         if (wlen > 0) {
             std::wstring ws((size_t)wlen, L'\0');
             MultiByteToWideChar(CP_UTF8, 0, s.c_str(), (int)s.size(), ws.data(), wlen);
-            DWORD wroteW = 0;
 
-            // Try our console handle first
-            if (hFile_ && hFile_ != INVALID_HANDLE_VALUE) {
-                if (WriteConsoleW(hFile_, ws.c_str(), (DWORD)ws.size(), &wroteW, nullptr)) return;
+            // Write in chunks if needed (WriteConsoleW has buffer limits)
+            const wchar_t* ptr = ws.c_str();
+            DWORD remaining = (DWORD)ws.size();
+
+            while (remaining > 0) {
+                DWORD wroteW = 0;
+                DWORD toWrite = (remaining > 8192) ? 8192 : remaining;
+
+                // Try dedicated console handle first (most reliable)
+                if (hConOut_ && hConOut_ != INVALID_HANDLE_VALUE) {
+                    if (WriteConsoleW(hConOut_, ptr, toWrite, &wroteW, nullptr) && wroteW > 0) {
+                        ptr += wroteW;
+                        remaining -= wroteW;
+                        continue;
+                    }
+                }
+
+                // Fallback: try STD_OUTPUT_HANDLE
+                HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+                if (hOut != INVALID_HANDLE_VALUE) {
+                    if (WriteConsoleW(hOut, ptr, toWrite, &wroteW, nullptr) && wroteW > 0) {
+                        ptr += wroteW;
+                        remaining -= wroteW;
+                        continue;
+                    }
+                }
+
+                // If WriteConsoleW fails (e.g., redirected output), fall back to WriteFile
+                // with UTF-8 bytes. The console code page should be set to 65001.
+                break;
             }
 
-            // Fallback: try STD_OUTPUT_HANDLE with WriteConsoleW
-            HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
-            if (hOut != INVALID_HANDLE_VALUE) {
-                if (WriteConsoleW(hOut, ws.c_str(), (DWORD)ws.size(), &wroteW, nullptr)) return;
-            }
+            // If we wrote everything via WriteConsoleW, we're done
+            if (remaining == 0) return;
         }
 
-        // Last resort fallback: WriteFile (may not handle Unicode properly but ensures output)
+        // Last resort fallback: WriteFile with UTF-8 bytes
+        // This path is used when output is redirected or WriteConsoleW fails
         HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
         if (hOut != INVALID_HANDLE_VALUE) {
             DWORD wrote = 0;
@@ -851,17 +894,23 @@ public:
 private:
     void init(){
 #ifdef _WIN32
-        // Try to get console handle with best mode for smooth output
-        hFile_ = CreateFileA("CONOUT$", GENERIC_READ | GENERIC_WRITE,
-                             FILE_SHARE_WRITE | FILE_SHARE_READ,
-                             NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-        if (hFile_ != INVALID_HANDLE_VALUE) {
-            // Enable VT processing for best ANSI support
+        // Set UTF-8 code pages for the console FIRST
+        // This is essential for proper Unicode display
+        SetConsoleOutputCP(CP_UTF8);
+        SetConsoleCP(CP_UTF8);
+
+        // Get a dedicated console output handle for WriteConsoleW
+        // CONOUT$ always points to the console even if stdout is redirected
+        hConOut_ = CreateFileA("CONOUT$", GENERIC_READ | GENERIC_WRITE,
+                               FILE_SHARE_WRITE | FILE_SHARE_READ,
+                               NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+        if (hConOut_ != INVALID_HANDLE_VALUE) {
+            // Enable VT processing for ANSI escape sequence support
             DWORD mode = 0;
-            if (GetConsoleMode(hFile_, &mode)) {
+            if (GetConsoleMode(hConOut_, &mode)) {
                 mode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
                 mode |= ENABLE_PROCESSED_OUTPUT;
-                SetConsoleMode(hFile_, mode);
+                SetConsoleMode(hConOut_, mode);
             }
         }
 #else
@@ -870,7 +919,7 @@ private:
 #endif
     }
 #ifdef _WIN32
-    HANDLE hFile_{};
+    HANDLE hConOut_{};  // Dedicated console output handle
 #else
     int fd_ = -1;
 #endif


### PR DESCRIPTION
- Add UTF-8 compiler flags for all compilers (MSVC: /utf-8, GCC/Clang: -finput-charset=UTF-8 -fexec-charset=UTF-8)
- Add UTF-8 pragma documentation for source file encoding requirements
- Improve ConsoleWriter to use WriteConsoleW exclusively for UTF-8 output
- Set SetConsoleOutputCP/SetConsoleCP(CP_UTF8) in ConsoleWriter::init()
- Use dedicated CONOUT$ handle for more reliable console output
- Write in chunks to handle large buffers with WriteConsoleW

This bypasses the problematic byte-stream layer on Windows consoles that causes UTF-8 mojibake even when the code page is set to 65001. By converting UTF-8 to UTF-16 and using WriteConsoleW, we write directly to the console buffer.