### PR TITLE
Critical fix: Transaction broadcast race condition and relay bug

### DIFF
--- a/src/p2p.cpp
+++ b/src/p2p.cpp
@@ -2764,6 +2764,40 @@ void P2P::broadcast_inv_tx(const std::vector<uint8_t>& txid){
     if (announce_tx_q_.size() < 8192) announce_tx_q_.push_back(txid);
 }
 
+// CRITICAL FIX: Store raw transaction for serving to peers
+// This is called by RPC sendrawtransaction so peers can fetch the full tx
+// after receiving the invtx announcement. Without this, peers would send
+// gettx but we'd have nothing to serve them!
+void P2P::store_tx_for_relay(const std::vector<uint8_t>& txid, const std::vector<uint8_t>& raw_tx){
+    if (txid.size() != 32 || raw_tx.empty()) return;
+
+    std::string key;
+    key.reserve(64);
+    static const char hex[] = "0123456789abcdef";
+    for (uint8_t b : txid) {
+        key.push_back(hex[b >> 4]);
+        key.push_back(hex[b & 0xf]);
+    }
+
+    // Note: No lock needed here since this is called from RPC thread
+    // and the main loop accesses tx_store_ from its own thread.
+    // However, for safety, we should use the announce_tx_mu_ lock.
+    std::lock_guard<std::mutex> lk(announce_tx_mu_);
+
+    if (tx_store_.find(key) == tx_store_.end()) {
+        tx_store_[key] = raw_tx;
+        tx_order_.push_back(key);
+        if (tx_store_.size() > MIQ_TX_STORE_MAX) {
+            auto victim = tx_order_.front();
+            tx_order_.pop_front();
+            tx_store_.erase(victim);
+        }
+    }
+
+    // Also mark as seen so we don't process it again if a peer relays it back
+    seen_txids_.insert(key);
+}
+
 static void trickle_flush(){
     int64_t tnow = now_ms();
     for (auto& kv : g_trickle_q) {
@@ -5254,8 +5288,13 @@ void P2P::loop(){
                             if (!inv_tick(1)) { continue; }
                             auto key = hexkey(m.payload);
                             if (!remember_inv(key)) { continue; }
+                            // CRITICAL FIX: Do NOT insert into seen_txids_ here!
+                            // Only check if we've already processed this transaction.
+                            // The actual insert into seen_txids_ happens in the "tx" handler
+                            // AFTER successful processing. The old code inserted here which
+                            // caused the tx handler to skip processing when the actual tx
+                            // data arrived (because seen_txids_.insert().second would be false).
                             if (!seen_txids_.count(key)) {
-                                seen_txids_.insert(key);
                                 request_tx(ps, m.payload);
                             }
                         }

--- a/src/p2p.h
+++ b/src/p2p.h
@@ -409,6 +409,11 @@ public:
     void broadcast_inv_block(const std::vector<uint8_t>& h);
     void broadcast_inv_tx(const std::vector<uint8_t>& txid);
 
+    // CRITICAL FIX: Store raw transaction for serving to peers via gettx
+    // This must be called when a tx is accepted via RPC (sendrawtransaction)
+    // so that peers can fetch the full tx after receiving the invtx announcement
+    void store_tx_for_relay(const std::vector<uint8_t>& txid, const std::vector<uint8_t>& raw_tx);
+
     // BIP130 sendheaders support
     void send_sendheaders(PeerState& ps);
     void broadcast_header(const std::vector<uint8_t>& header_data);

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -1171,6 +1171,9 @@ std::string RpcService::handle(const std::string& body){
                 // Without this, transactions only sit in local mempool and never propagate!
                 if(p2p_) {
                     std::vector<uint8_t> txid = tx.txid();
+                    // CRITICAL FIX: Store raw tx so we can serve it when peers request via gettx
+                    // Without this, peers receive invtx, send gettx, but we have nothing to serve!
+                    p2p_->store_tx_for_relay(txid, raw);
                     p2p_->broadcast_inv_tx(txid);
                 }
                 JNode r; r.v = std::string(to_hex(tx.txid())); return json_dump(r);


### PR DESCRIPTION
This commit fixes two critical bugs that prevented transactions from being confirmed in the network:

Bug 1 - Race condition in invtx/tx handlers:
- When receiving an "invtx" announcement, the code was inserting the txid into seen_txids_ BEFORE receiving the actual transaction data
- When the "tx" data later arrived, seen_txids_.insert().second returned false, causing the entire processing block to be skipped
- Result: Transactions were never accepted into mempool, stored, or relayed

Bug 2 - RPC transactions not stored for relay:
- When transactions were submitted via RPC (sendrawtransaction), the raw tx bytes were not stored in tx_store_
- When peers received the "invtx" and sent "gettx", there was nothing to serve them
- Result: Transactions could not propagate beyond the local node

Fixes:
- Remove premature seen_txids_ insert from invtx handler
- Add store_tx_for_relay() method to store raw tx bytes for peer requests
- Call store_tx_for_relay() from sendrawtransaction RPC handler