### PR TITLE
Fix transaction display ordering and pending cleanup bugs

### DIFF
--- a/src/wallet/spv_simple.cpp
+++ b/src/wallet/spv_simple.cpp
@@ -332,6 +332,12 @@ struct UtxoMemCache {
     }
 };
 
+// CRITICAL FIX: Expose cache invalidation for use after sending transactions
+// This ensures the next UTXO fetch gets fresh data from the network
+void spv_invalidate_mem_cache() {
+    UtxoMemCache::instance().invalidate();
+}
+
 static inline std::string path_join(const std::string& dir, const char* fname){
     if (dir.empty()) return std::string(fname);
     char sep = '/';

--- a/src/wallet/spv_simple.h
+++ b/src/wallet/spv_simple.h
@@ -40,4 +40,8 @@ bool spv_collect_utxos(
 // Optional: quick sum helper.
 uint64_t spv_sum_value(const std::vector<UtxoLite>& v);
 
+// CRITICAL FIX: Invalidate in-memory UTXO cache after sending transactions
+// This ensures fresh data is fetched from network after spending UTXOs
+void spv_invalidate_mem_cache();
+
 }


### PR DESCRIPTION
Critical fixes for two wallet bugs:

1. Transaction Display Ordering Fix:
   - sort_transactions() now uses block_height as primary sort key
   - Matches the sorting logic in sort_tx_history()
   - Timestamp alone was unreliable since it's estimated during sync
   - Unconfirmed (height=0) transactions appear first
   - Consistent tie-breaking with txid_hex

2. Pending Transactions Cleanup Fix:
   - Added spv_invalidate_mem_cache() to force fresh UTXO fetch
   - Cache invalidation after sending transactions ensures spent UTXOs are properly detected on next sync
   - Auto-refresh now actually performs UTXO refresh every 60s
   - Auto-refresh cleans up pending entries for confirmed TXs
   - Auto-refresh updates transaction confirmations

These fixes ensure:
- Transactions display in correct chronological order by block height
- Pending balance clears when transactions are confirmed
- Background sync keeps wallet state up-to-date automatically