### PR TITLE
Remove transaction limits - like Bitcoin, allow any amount

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -42,7 +42,7 @@
 #endif
 
 #ifndef MAX_TX_SIZE
-#define MIQ_FALLBACK_MAX_TX_SIZE (100u * 1024u) // 100 KiB default
+#define MIQ_FALLBACK_MAX_TX_SIZE (4u * 1024u * 1024u) // 4 MiB default (no tx size limit)
 #else
 #define MIQ_FALLBACK_MAX_TX_SIZE (MAX_TX_SIZE)
 #endif
@@ -407,7 +407,7 @@ static miq::ReorgManager g_reorg;
 static miq::gcs::FilterStore g_filter_store;
 #endif
 
-static constexpr size_t MAX_BLOCK_SIZE_LOCAL = 1 * 1024 * 1024; // 1 MiB
+static constexpr size_t MAX_BLOCK_SIZE_LOCAL = 4 * 1024 * 1024; // 4 MiB (match MAX_BLOCK_SIZE)
 
 // CRITICAL FIX: Add mutex to protect global header cache from race conditions
 static std::mutex g_header_full_mtx;

--- a/src/cli/miqwallet.cpp
+++ b/src/cli/miqwallet.cpp
@@ -310,7 +310,8 @@ namespace wallet_config {
     static constexpr size_t MAX_UTXO_COUNT = 100000;
     static constexpr size_t MAX_TX_INPUTS = 500;
     static constexpr size_t MAX_TX_OUTPUTS = 50;
-    static constexpr uint64_t MAX_SINGLE_TX_VALUE = 1000000ULL * 100000000ULL;
+    // No transfer limit - like Bitcoin, allow any amount up to total supply
+    static constexpr uint64_t MAX_SINGLE_TX_VALUE = 26280000ULL * 100000000ULL;  // MAX_MONEY
     static constexpr uint64_t DUST_THRESHOLD = 546;
     static constexpr uint64_t MIN_RELAY_FEE = 1000;  // Minimum fee for relay
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -242,8 +242,9 @@ static constexpr size_t DNS_SEEDS_COUNT = sizeof(DNS_SEEDS) / sizeof(DNS_SEEDS[0
 static constexpr int64_t MAX_TIME_SKEW = 2*60*60; // 2 hours
 
 // === PRODUCTION SECURITY CAPS ===
+// Like Bitcoin, allow large transactions that can fill the entire block
 static constexpr size_t MAX_BLOCK_SIZE = 4 * 1024 * 1024;  // 4 MiB (scalable)
-static constexpr size_t MAX_TX_SIZE    = 400 * 1024;       // 400 KiB
+static constexpr size_t MAX_TX_SIZE    = 4 * 1024 * 1024;  // 4 MiB (no tx size limit within block)
 static constexpr size_t MAX_MSG_SIZE   = 8 * 1024 * 1024;  // 8 MiB (for large INVs)
 
 // Optional: default RPC token (empty = no token unless MIQ_RPC_TOKEN env set)
@@ -429,9 +430,9 @@ static constexpr uint32_t MIN_PEER_PROTO_VERSION = 70015;  // Minimum supported
 #endif
 
 // === WALLET TRANSFER LIMITS ===
-// Maximum amount that can be sent in a single transfer (anti-fraud protection)
+// No transfer limit - like Bitcoin, users can send any amount up to their balance
 #ifndef MIQ_MAX_TRANSFER_AMOUNT
-#define MIQ_MAX_TRANSFER_AMOUNT (2000ULL * COIN)  // 2000 MIQ per transfer
+#define MIQ_MAX_TRANSFER_AMOUNT MAX_MONEY  // No limit - can send up to total supply
 #endif
 
 // === RBF (Replace-By-Fee) SUPPORT ===

--- a/src/netmsg.cpp
+++ b/src/netmsg.cpp
@@ -31,7 +31,7 @@
 #endif
 
 #ifndef MAX_TX_SIZE
-#define MIQ_FALLBACK_MAX_TX_SIZE  (1024u * 1024u)        // 1 MiB cap for tx wire payloads
+#define MIQ_FALLBACK_MAX_TX_SIZE  (4u * 1024u * 1024u)   // 4 MiB (no tx size limit)
 #else
 #define MIQ_FALLBACK_MAX_TX_SIZE  (MAX_TX_SIZE)
 #endif

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -2611,14 +2611,8 @@ std::string RpcService::handle(const std::string& body){
             catch(...) { return err("bad amount"); }
             if (amount == 0) return err("amount must be >0");
 
-            // SECURITY: Enforce maximum transfer limit
-            if (amount > MIQ_MAX_TRANSFER_AMOUNT) {
-                char buf[256];
-                std::snprintf(buf, sizeof(buf),
-                    "amount exceeds maximum transfer limit of %llu MIQ per transaction",
-                    (unsigned long long)(MIQ_MAX_TRANSFER_AMOUNT / COIN));
-                return err(buf);
-            }
+            // No transfer limit - like Bitcoin, allow any amount up to user's balance
+            // The only limit is MAX_MONEY (total supply) which is checked elsewhere
 
             // Load wallet data
             std::string wdir = default_wallet_file();


### PR DESCRIPTION
- Remove 2000 MIQ per-transfer limit (was anti-fraud, now no limit)
- Increase MAX_TX_SIZE from 400 KiB to 4 MiB (can fill entire block)
- Increase MAX_BLOCK_SIZE_LOCAL from 1 MiB to 4 MiB
- Update wallet MAX_SINGLE_TX_VALUE to total supply (26.28M MIQ)
- Update fallback tx size limits in chain.cpp and netmsg.cpp

This makes MiqroChain work like Bitcoin with no arbitrary transfer limits. Users can now send any amount (50k, 100k, etc.) and large transactions with many inputs will be properly mined.