### PR TITLE
Fix critical cross-node transaction propagation bugs

### DIFF
--- a/src/p2p.h
+++ b/src/p2p.h
@@ -543,7 +543,8 @@ public:
 
 private:
     // tx relay (basic)
-    void request_tx(PeerState& ps, const std::vector<uint8_t>& txid);
+    // CRITICAL FIX: Returns bool to indicate if gettx was actually sent
+    bool request_tx(PeerState& ps, const std::vector<uint8_t>& txid);
     void send_tx(Sock sock, const std::vector<uint8_t>& raw);
     void send_block(Sock s, const std::vector<uint8_t>& raw);
 


### PR DESCRIPTION
This fixes multiple bugs that prevented transactions created on one node from being properly seen and mined by other nodes:

1. **remember_inv ordering bug (CRITICAL)**: The invtx handler was calling remember_inv() BEFORE attempting request_tx(). If request_tx failed (due to rate limiting or max inflight), the txid was still marked as "remembered" and subsequent invtx messages from the same peer would be skipped. Now we only mark as remembered AFTER a successful request or if we already have the tx.

2. **Silent request_tx failures**: The request_tx() function could silently fail due to rate limiting or max inflight limit without any logging, making debugging impossible. Now it returns bool and logs failures at DEBUG level.

3. **Missing verack_ok checks in tx broadcast**: Transaction broadcast and relay was sending to ALL peers including those that haven't completed handshake. Now we only send to peers with verack_ok=true. If no peers are ready, we re-queue the announcements.

4. **Don't relay back to sender**: When relaying accepted transactions, we now skip the peer that sent us the tx to avoid unnecessary traffic.

These fixes ensure that:
- Transactions properly propagate between nodes
- Failed requests can be retried when the peer re-announces
- Only handshake-complete peers receive transaction announcements
- Better debugging through logging