### PR TITLE
Fix request timeout to also clear recent_inv_keys

### DIFF
--- a/src/p2p.cpp
+++ b/src/p2p.cpp
@@ -4101,6 +4101,10 @@ void P2P::loop(){
                 auto pit = peers_.find(e.first);
                 if (pit != peers_.end()) {
                     pit->second.inflight_tx.erase(e.second);
+                    // CRITICAL FIX: Also clear from recent_inv_keys so the peer can re-announce
+                    // Without this, if a request times out, the peer would never be able to
+                    // successfully announce this tx to us again (we'd skip it in invtx handler)
+                    pit->second.recent_inv_keys.erase(e.second);
                 }
             }
             if (!expired_tx.empty()) {


### PR DESCRIPTION
When a gettx request times out (30s), we were clearing from inflight_tx but NOT from recent_inv_keys. This meant the peer could never successfully re-announce the same transaction - we'd skip it in the invtx handler because it was still in recent_inv_keys.

Now we clear from recent_inv_keys on timeout, allowing the peer to re-announce and us to re-request the transaction.