### PR TITLE
Remove false seed detection (hairpin assumption)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1219,17 +1219,6 @@ static std::vector<std::string> local_ip_strings(){
     return false;
 }
 
-static inline bool is_private_v4(const std::string& ip){
-    return ip.rfind("10.",0)==0
-        || ip.rfind("192.168.",0)==0
-        || (ip.rfind("172.",0)==0 && [] (const std::string& s){
-              // 172.16.0.0/12
-              int a=0; char dot=0;
-              if (std::sscanf(s.c_str(),"172.%d%c",&a,&dot)==2 && dot=='.') return (a>=16 && a<=31);
-              return false;
-           }(ip));
-}
-
 struct SeedRole {
     bool we_are_seed{false};
     std::string detail;
@@ -4018,13 +4007,11 @@ static bool perform_ibd_sync(Chain& chain, P2P* p2p, const std::string& datadir,
     uint64_t       lastProgressMs        = now_ms();
     uint64_t       lastHeight            = chain.height();
     uint64_t       height_at_seed_connect= lastHeight;
-    uint32_t       seed_dials            = 0;
 
-    // Make sure we’ve nudged the seed right away.
+    // Make sure we've nudged the seed right away.
     if (!we_are_seed) {
         p2p->connect_seed(seed_host_cstr(), P2P_PORT);
         lastSeedDialMs = now_ms();
-        ++seed_dials;
     } else {
         log_info(std::string("Seed self-detect: skipping outbound connect to ")
                  + seed_host_cstr() + " (waiting for inbound peers).");
@@ -4069,18 +4056,6 @@ static bool perform_ibd_sync(Chain& chain, P2P* p2p, const std::string& datadir,
             if (!we_are_seed && verack_peers == 0 && (now_ms() - lastSeedDialMs > kSeedNudgeMs)) {
                 p2p->connect_seed(seed_host_cstr(), P2P_PORT);
                 lastSeedDialMs = now_ms();
-                ++seed_dials;
-                if (seed_dials >= 5) {
-                    auto ips = resolve_host_ip_strings(seed_host_cstr());
-                    bool any_public = false;
-                    for (auto& ip : ips) { if (!is_private_v4(ip) && !is_loopback_or_linklocal(ip)) { any_public = true; break; } }
-                    if (any_public && p2p && p2p->snapshot_peers().empty()){
-                        g_assume_seed_hairpin.store(true);
-                        we_are_seed = true;
-                        log_warn("IBD: assuming SEED mode due to probable NAT hairpin (repeated seed dial fails with 0 peers).");
-                        if (tui && can_tui) tui->set_banner("Seed solo mode (hairpin) — waiting for inbound peers…");
-                    }
-                }
             }
 
             if (now_ms() > handshake_deadline_ms) {
@@ -4094,15 +4069,7 @@ static bool perform_ibd_sync(Chain& chain, P2P* p2p, const std::string& datadir,
                     }
                     return true; // treat IBD as trivially complete to unlock mining
                 } else {
-                    if (g_assume_seed_hairpin.load()){
-                        log_warn("IBD: hairpin seed assumption during handshake — proceeding in SOLO-SEED mode.");
-                        if (tui && can_tui) {
-                            tui->mark_step_ok("Peer handshake (verack)");
-                            tui->set_banner("Seed solo mode (hairpin) — mining unlocked.");
-                            tui->set_ibd_progress(chain.height(), chain.height(), 0, "complete", seed_host_cstr(), true);
-                        }
-                        return true;
-                    }
+                    // Regular node: handshake failed - report error
                     out_err = "no peers completed handshake (verack)";
                     if (tui && can_tui) tui->mark_step_fail("Peer handshake (verack)");
                     return false;
@@ -4132,7 +4099,6 @@ static bool perform_ibd_sync(Chain& chain, P2P* p2p, const std::string& datadir,
         if (!we_are_seed && verack_peers == 0 && now_ms() - lastSeedDialMs > kSeedNudgeMs) {
             p2p->connect_seed(seed_host_cstr(), P2P_PORT);
             lastSeedDialMs = now_ms();
-            ++seed_dials;
         }
 
         // Early no-peer failure


### PR DESCRIPTION
The automatic hairpin detection was incorrectly triggering on regular nodes when peers connected but disconnected before completing the verack handshake. This caused nodes to wrongly think they were the seed server, preventing them from syncing.

The hairpin logic assumed that after 5 failed seed dials with no peers, the node must be the seed behind NAT. But this failed when:
1. Peers connect successfully
2. Peers disconnect before verack completes
3. snapshot_peers() returns empty at check time
4. Node wrongly assumes seed mode

Fix: Remove the automatic hairpin detection entirely. If a node is the actual seed, it should either:
- Have its IP match the DNS_SEED A record (auto-detected)
- Set MIQ_FORCE_SEED=1 explicitly

This ensures regular nodes don't get stuck thinking they're seeds.

Also removed the now-unused seed_dials variable to fix -Werror.