### PR TITLE
Fix stratum mining - time/nonce encoding and difficulty calculation

### DIFF
--- a/src/stratum/stratum_server.h
+++ b/src/stratum/stratum_server.h
@@ -41,7 +41,7 @@ struct StratumJob {
     std::vector<std::string> merkle_branches;
     uint32_t version;
     uint32_t bits;
-    uint32_t time;
+    uint64_t time;  // MIQ uses 64-bit timestamps
     uint64_t height;
     bool clean_jobs;                      // True if new block, clear old jobs
 


### PR DESCRIPTION
Multiple critical bugs were preventing stratum miners from working:

1. TIME/NONCE BYTE ORDER MISMATCH:
   - Client sent LE-encoded bytes as hex (e.g., time=0x674E2D0E -> "0e2d4e67")
   - Server parsed hex as NUMBER then LE-encoded again (double swap)
   - Headers never matched -> shares always rejected
   - FIX: Client now sends numeric value as hex (e.g., "000000000674e2d0e")

2. 32-BIT vs 64-BIT TIME:
   - MIQ uses 64-bit timestamps in block headers
   - Server was sending 32-bit time (8 hex chars)
   - Client was parsing/building with mixed sizes
   - FIX: Both now use 64-bit time consistently (16 hex chars)

3. WRONG DIFFICULTY FOR NEXT BLOCK:
   - Server used tip.bits directly for job difficulty
   - This is wrong at difficulty adjustment boundaries
   - FIX: Now uses epoch_next_bits() like getblocktemplate RPC

Changes:
- src/stratum/stratum_server.h: job.time changed to uint64_t
- src/stratum/stratum_server.cpp: 64-bit time, epoch_next_bits for bits
- src/cli/miqminer_rpc.cpp: 64-bit time, numeric hex encoding for time/nonce