### PR TITLE
Fix block storage normalization and byte-order compatibility

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -590,7 +590,11 @@ bool Chain::validate_header(const BlockHeader& h, std::string& err) const {
 
 bool Chain::header_exists(const std::vector<uint8_t>& h) const {
     MIQ_CHAIN_GUARD();
-    return header_index_.find(hk(h)) != header_index_.end();
+    if (header_index_.find(hk(h)) != header_index_.end()) return true;
+    // COMPAT FIX: Try reversed hash for headers stored with wrong byte-order
+    std::vector<uint8_t> h_reversed = h;
+    std::reverse(h_reversed.begin(), h_reversed.end());
+    return header_index_.find(hk(h_reversed)) != header_index_.end();
 }
 
 std::vector<uint8_t> Chain::best_header_hash() const {
@@ -651,36 +655,52 @@ bool Chain::accept_header(const BlockHeader& h, std::string& err) {
     long double parent_work = 0.0L;
     bool found_parent = false;
 
+    // COMPAT FIX: Try both byte-orders for parent lookup
     auto itp = header_index_.find(hk(h.prev_hash));
+    if (itp == header_index_.end()) {
+        // Try reversed hash
+        std::vector<uint8_t> prev_reversed = h.prev_hash;
+        std::reverse(prev_reversed.begin(), prev_reversed.end());
+        itp = header_index_.find(hk(prev_reversed));
+    }
     if (itp != header_index_.end()) {
         parent_height = itp->second.height;
         parent_work   = itp->second.work_sum;
         found_parent = true;
-    } else if (h.prev_hash == tip_.hash) {
-        parent_height = tip_.height;
-        // Calculate cumulative work up to current tip
-        parent_work = 0.0L;
-        // Walk back from tip to genesis to calculate total work
-        std::vector<uint8_t> cur_hash = tip_.hash;
-        uint64_t cur_height = tip_.height;
-        while (cur_height > 0) {
-            Block b;
-            if (get_block_by_hash(cur_hash, b)) {
-                parent_work += work_from_bits(b.header.bits);
-                cur_hash = b.header.prev_hash;
-                cur_height--;
-            } else break;
+    } else {
+        // COMPAT FIX: Check tip_.hash match with both byte-orders
+        bool matches_tip = (h.prev_hash == tip_.hash);
+        if (!matches_tip) {
+            std::vector<uint8_t> prev_reversed = h.prev_hash;
+            std::reverse(prev_reversed.begin(), prev_reversed.end());
+            matches_tip = (prev_reversed == tip_.hash);
         }
-        // Add work for genesis if at height 0
-        if (cur_height == 0) {
-            parent_work += work_from_bits(GENESIS_BITS);
+        if (matches_tip) {
+            parent_height = tip_.height;
+            // Calculate cumulative work up to current tip
+            parent_work = 0.0L;
+            // Walk back from tip to genesis to calculate total work
+            std::vector<uint8_t> cur_hash = tip_.hash;
+            uint64_t cur_height = tip_.height;
+            while (cur_height > 0) {
+                Block b;
+                if (get_block_by_hash(cur_hash, b)) {
+                    parent_work += work_from_bits(b.header.bits);
+                    cur_hash = b.header.prev_hash;
+                    cur_height--;
+                } else break;
+            }
+            // Add work for genesis if at height 0
+            if (cur_height == 0) {
+                parent_work += work_from_bits(GENESIS_BITS);
+            }
+            found_parent = true;
+        } else if (h.prev_hash == std::vector<uint8_t>(32, 0)) {
+            // Genesis block (prev_hash is all zeros)
+            parent_height = 0;
+            parent_work = 0.0L;
+            found_parent = true;
         }
-        found_parent = true;
-    } else if (h.prev_hash == std::vector<uint8_t>(32, 0)) {
-        // Genesis block (prev_hash is all zeros)
-        parent_height = 0;
-        parent_work = 0.0L;
-        found_parent = true;
     }
 
     // CRITICAL FIX: If we can't find the parent, reject the header
@@ -1066,6 +1086,11 @@ bool Chain::read_block_any(const std::vector<uint8_t>& h, Block& out) const{
     std::vector<uint8_t> raw;
     if (storage_.read_block_by_hash(h, raw)) return deser_block(raw, out);
     if (orphan_get(h, raw)) return deser_block(raw, out);
+    // COMPAT FIX: Try reversed hash for blocks stored with wrong byte-order
+    std::vector<uint8_t> h_reversed = h;
+    std::reverse(h_reversed.begin(), h_reversed.end());
+    if (storage_.read_block_by_hash(h_reversed, raw)) return deser_block(raw, out);
+    if (orphan_get(h_reversed, raw)) return deser_block(raw, out);
     return false;
 }
 
@@ -1453,12 +1478,13 @@ bool Chain::verify_block(const Block& b, std::string& err) const{
     }
 
     // NETWORK COMPAT FIX: Try both byte-orders for prev_hash comparison
-    // This allows blocks to be stored in original wire format while still validating
-    std::vector<uint8_t> prev_reversed = b.header.prev_hash;
-    std::reverse(prev_reversed.begin(), prev_reversed.end());
-    if(b.header.prev_hash != tip_.hash && prev_reversed != tip_.hash){
-        err="bad prev hash";
-        return false;
+    if (b.header.prev_hash != tip_.hash) {
+        std::vector<uint8_t> prev_reversed = b.header.prev_hash;
+        std::reverse(prev_reversed.begin(), prev_reversed.end());
+        if (prev_reversed != tip_.hash) {
+            err = "bad prev hash";
+            return false;
+        }
     }
 
     // MTP
@@ -1493,12 +1519,13 @@ bool Chain::verify_block(const Block& b, std::string& err) const{
         }
         auto mr = merkle_root(txids);
         // NETWORK COMPAT FIX: Try both byte-orders for merkle root comparison
-        // This allows blocks to be stored in original wire format while still validating
-        std::vector<uint8_t> mr_reversed = mr;
-        std::reverse(mr_reversed.begin(), mr_reversed.end());
-        if(mr != b.header.merkle_root && mr_reversed != b.header.merkle_root){
-            err="bad merkle";
-            return false;
+        if (mr != b.header.merkle_root) {
+            std::vector<uint8_t> mr_reversed = mr;
+            std::reverse(mr_reversed.begin(), mr_reversed.end());
+            if (mr_reversed != b.header.merkle_root) {
+                err = "bad merkle";
+                return false;
+            }
         }
     }
 
@@ -1899,14 +1926,37 @@ bool Chain::submit_block(const Block& b, std::string& err){
     
     if (!verify_block(b, err)) return false;
 
-    if (have_block(b.block_hash())) return true;
+    // NETWORK COMPAT FIX: Create normalized copy for consistent storage
+    // This ensures block_hash() is computed correctly regardless of incoming byte-order
+    Block normalized_block = b;
+
+    // Normalize prev_hash to match tip_.hash format
+    if (normalized_block.header.prev_hash != tip_.hash) {
+        std::reverse(normalized_block.header.prev_hash.begin(),
+                     normalized_block.header.prev_hash.end());
+    }
+
+    // Normalize merkle_root to match computed merkle root
+    {
+        std::vector<std::vector<uint8_t>> txids;
+        txids.reserve(normalized_block.txs.size());
+        for (const auto& tx : normalized_block.txs) {
+            txids.push_back(tx.txid());
+        }
+        auto mr = merkle_root(txids);
+        if (mr != normalized_block.header.merkle_root) {
+            normalized_block.header.merkle_root = mr;
+        }
+    }
+
+    if (have_block(normalized_block.block_hash())) return true;
 
     // --- Collect undo BEFORE mutating UTXO ---
     std::vector<UndoIn> undo;
-    undo.reserve(b.txs.size() * 2);
+    undo.reserve(normalized_block.txs.size() * 2);
 
-    for (size_t ti = 1; ti < b.txs.size(); ++ti){
-        const auto& tx = b.txs[ti];
+    for (size_t ti = 1; ti < normalized_block.txs.size(); ++ti){
+        const auto& tx = normalized_block.txs[ti];
         for (const auto& in : tx.vin){
             UTXOEntry e;
             if (!utxo_.get(in.prev.txid, in.prev.vout, e)){
@@ -1918,11 +1968,11 @@ bool Chain::submit_block(const Block& b, std::string& err){
     }
 
     // Persist the block body
-    storage_.append_block(ser_block(b), b.block_hash());
+    storage_.append_block(ser_block(normalized_block), normalized_block.block_hash());
 
     // --- Crash-safety: write undo BEFORE UTXO mutation ---
     const uint64_t new_height = tip_.height + 1;
-    const auto     new_hash   = b.block_hash();
+    const auto     new_hash   = normalized_block.block_hash();
     if (!write_undo_file(datadir_, new_height, new_hash, undo)) {
         err = "failed to write undo";
         return false;
@@ -1972,7 +2022,7 @@ bool Chain::submit_block(const Block& b, std::string& err){
     }
 
     // Also cache the full header for serving to peers
-    set_header_full(hk(new_hash), b.header);  // THREAD-SAFE
+    set_header_full(hk(new_hash), normalized_block.header);  // THREAD-SAFE
 
     // CRITICAL FIX: Add all transactions to the transaction index for fast lookups
     // This enables O(1) transaction lookup by txid instead of scanning blocks
@@ -2101,14 +2151,26 @@ bool Chain::get_block_by_index(size_t idx, Block& out) const{
 bool Chain::get_block_by_hash(const std::vector<uint8_t>& h, Block& out) const{
     MIQ_CHAIN_GUARD();
     std::vector<uint8_t> raw;
-    if(!storage_.read_block_by_hash(h, raw)) return false;
-    return deser_block(raw, out);
+    if (storage_.read_block_by_hash(h, raw)) {
+        return deser_block(raw, out);
+    }
+    // COMPAT FIX: Try reversed hash for blocks stored with wrong byte-order
+    std::vector<uint8_t> h_reversed = h;
+    std::reverse(h_reversed.begin(), h_reversed.end());
+    if (storage_.read_block_by_hash(h_reversed, raw)) {
+        return deser_block(raw, out);
+    }
+    return false;
 }
 
 bool Chain::have_block(const std::vector<uint8_t>& h) const{
     MIQ_CHAIN_GUARD();
     std::vector<uint8_t> raw;
-    return storage_.read_block_by_hash(h, raw);
+    if (storage_.read_block_by_hash(h, raw)) return true;
+    // COMPAT FIX: Try reversed hash for blocks stored with wrong byte-order
+    std::vector<uint8_t> h_reversed = h;
+    std::reverse(h_reversed.begin(), h_reversed.end());
+    return storage_.read_block_by_hash(h_reversed, raw);
 }
 
 long double Chain::work_from_bits_public(uint32_t bits) {
@@ -2139,6 +2201,12 @@ bool Chain::get_block_by_hash_fast(const std::vector<uint8_t>& hash, Block& out)
     // Use hash index for O(1) lookup
     int64_t height = hashindex_.get(hash);
     if (height < 0) {
+        // COMPAT FIX: Try reversed hash for blocks stored with wrong byte-order
+        std::vector<uint8_t> hash_reversed = hash;
+        std::reverse(hash_reversed.begin(), hash_reversed.end());
+        height = hashindex_.get(hash_reversed);
+    }
+    if (height < 0) {
         // Fallback to storage lookup (slower, O(n))
         return get_block_by_hash(hash, out);
     }
@@ -2148,7 +2216,14 @@ bool Chain::get_block_by_hash_fast(const std::vector<uint8_t>& hash, Block& out)
 
 int64_t Chain::get_height_by_hash(const std::vector<uint8_t>& hash) const {
     MIQ_CHAIN_GUARD();
-    return hashindex_.get(hash);
+    int64_t height = hashindex_.get(hash);
+    if (height < 0) {
+        // COMPAT FIX: Try reversed hash for blocks stored with wrong byte-order
+        std::vector<uint8_t> hash_reversed = hash;
+        std::reverse(hash_reversed.begin(), hash_reversed.end());
+        height = hashindex_.get(hash_reversed);
+    }
+    return height;
 }
 
 bool Chain::reindex_addresses(std::function<bool(uint64_t, uint64_t)> progress) {


### PR DESCRIPTION
This comprehensive fix ensures blocks are stored with consistent, normalized hashes for reliable network propagation:

Block Storage Normalization (submit_block):
- Create normalized copy before storage to ensure block_hash() is consistent regardless of incoming byte-order
- Normalize prev_hash to match tip_.hash format
- Normalize merkle_root to match computed merkle root
- Store normalized block with correct hash key for reliable lookups

Validation Byte-Order Tolerance (verify_block):
- Accept blocks with prev_hash in either byte-order
- Accept blocks with merkle_root in either byte-order
- Validation-only (no modification of const block)

Block Lookup Fallbacks:
- get_block_by_hash: Try reversed hash if primary lookup fails
- have_block: Try both hash orientations
- read_block_any: Try reversed hash for storage and orphans
- get_block_by_hash_fast: Try reversed hash in hashindex
- get_height_by_hash: Try reversed hash in hashindex

Header Handling:
- header_exists: Try both hash orientations
- accept_header: Try reversed prev_hash for parent lookup
- Support both byte-orders when checking tip_.hash match

These changes ensure:
1. New blocks are always stored with canonical hashes
2. Existing blocks with wrong hashes can still be found
3. Blocks relayed between nodes work regardless of format
4. The network can recover from byte-order inconsistencies