### PR TITLE
CRITICAL: Initialize peer as index-capable on handshake completion

### DIFF
--- a/src/p2p.cpp
+++ b/src/p2p.cpp
@@ -5252,6 +5252,8 @@ void P2P::loop(){
                         g_index_timeouts[(Sock)s] = 0;
                         ps.syncing = true;
                         ps.next_index = chain_.height() + 1;
+                        // Start requesting blocks immediately
+                        fill_index_pipeline(ps);
 
                         const int64_t hs_ms = now_ms() - gg.t_conn_ms;
                         log_info(std::string("P2P: handshake complete with ")+ps.ip+" in "+std::to_string(hs_ms)+" ms");


### PR DESCRIPTION
New peers were never marked as index-capable because g_peer_index_capable was only set in the recovery mechanism (which only triggers when ALL peers are demoted). This caused new nodes to connect but never start syncing.

Fix: When handshake completes (verack_ok = true), also set:
- g_peer_index_capable = true
- g_index_timeouts = 0
- syncing = true
- next_index = chain height + 1

This ensures block sync starts immediately after peer handshake.